### PR TITLE
Add instructions for simplifying DeepSeek

### DIFF
--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1,0 +1,339 @@
+Great, I’ll dive into the forked DeepSeek codebase to translate all Chinese or Mandarin content into English and assess which parts could benefit from conversion to Rust. The goal is to make the project lightweight enough to run efficiently on your laptop and well-documented enough for easy explanation. I’ll prioritize clarity, simplicity, and opportunities for modular, scalable improvements—especially with ideas like SQLite-based memory caching for context management.
+
+I’ll get started on this analysis and report back with a detailed PRD draft that reflects these goals.
+
+
+# DeepSeek Local-First Model – Product Requirements Document
+
+## Introduction and Goals
+
+We aim to **simplify and reimplement the DeepSeek AI model for local usage** on a personal laptop. The goal is to create a **self-contained, explainable, and efficient** version of DeepSeek that can run on modest hardware (Dell Inspiron 16 7630 2-in-1, Intel i7-1360P, 16 GB RAM, no high-end GPU). This project will prioritize **clarity, modular design, and thorough documentation** (with layman-friendly explanations) over raw performance. Key objectives include:
+
+* **Clarity & Explainability:** The codebase and documentation should be understandable by non-experts. Complex logic will be broken down with comments and guides that explain how the model works in simple terms.
+* **Local-First Performance:** Optimize for local CPU execution. Use lightweight components (e.g. SQLite for context storage) and efficient algorithms so that the system is responsive on a single laptop.
+* **Modularity & Flexibility:** Design the system in modules (e.g. model interface, context memory, etc.) to allow swapping out or upgrading components (for example, replacing a Python module with a Rust implementation) without rewriting everything.
+* **Rust Integration:** Identify parts of the pipeline where using Rust (rewriting or wrapping components) can significantly improve speed or reliability. Over time, migrate performance-critical or complex components from Python/C++ to Rust for better efficiency and safer concurrency.
+* **Resource Awareness:** Provide mechanisms to monitor and warn about resource usage. The system should detect if a requested operation (e.g. too long input context or model load) is likely to exceed memory or reasonable time, and alert the user instead of failing.
+* **Incremental Scaling:** Start with a **minimal viable product (MVP)** that works with a small model and basic features. Only add complexity (larger models, more features, caching layers, etc.) in later phases if needed, based on measured performance and user needs.
+
+By focusing on these goals, we aim to **iterate from a simple prototype to a robust local AI assistant** that remains transparent and manageable. The end result should be a platform that an individual developer (or small team) can easily understand, maintain, and extend, without requiring massive compute resources.
+
+## Background: DeepSeek Architecture and Challenges
+
+**DeepSeek** (from DeepSeek-AI) is a state-of-the-art large language model series that includes **DeepSeek-V3** and **DeepSeek-R1**, known for high performance in reasoning tasks. However, the official DeepSeek architecture is extremely complex and resource-intensive:
+
+* **Massive Model Size:** DeepSeek-V3 is a Mixture-of-Experts (MoE) model with **671 billion parameters (37B active per token)**. The full model (including a Multi-Token Prediction module) is ~685B parameters in size. Running this model requires **hundreds of GB of memory and powerful GPUs** – for example, DeepSeek-R1 (671B) would need on the order of **404 GB of VRAM (≈1 TB)** for inference. This is far beyond a personal laptop’s capacity. In fact, the DeepSeek documentation notes that the 671B model is “*a bit huge; for personal users, the hardware requirements are too high (plenty of disk space and GPUs are a must)*”.
+
+* **Advanced Architecture:** To achieve its performance, DeepSeek-V3 employs specialized techniques like **Multi-head Latent Attention (MLA)** and a custom MoE design (“DeepSeekMoE”). It also uses **FP8 mixed-precision training** and complex load-balancing strategies. These innovations improve speed and training efficiency on distributed hardware, but they introduce **significant complexity**. The codebase likely includes custom CUDA kernels, multi-GPU communication logic, and other optimizations that are **irrelevant or inefficient in a single-machine scenario**. For example, cross-node communication overlap in MoE training is critical for clusters, but on a laptop this adds needless overhead.
+
+* **Long Context Length:** DeepSeek models support a context window of **up to 128K tokens**. While impressive, such a long context is **impractical on 16 GB RAM** – processing 128K tokens could exhaust memory or be extremely slow on CPU. The current architecture doesn’t inherently warn users about this; it assumes the runtime can handle it. On constrained hardware, feeding such a large context could crash the program or swap to disk heavily. This is a clear area where we need to impose **safety checks** and possibly use alternative strategies (like selective retrieval of relevant context from a database rather than holding huge text in memory).
+
+* **Training Pipeline vs Inference Needs:** The repository likely contains code for **training** (reinforcement learning, supervised fine-tuning, distillation) and for distributed inference. For local usage, we **do not need training or multi-node inference**. The presence of training-specific code (e.g. reward models, optimizer logic, dataset pipelines) is an “inefficiency” for our purposes – it complicates the code without benefiting the local run. Similarly, multi-GPU or multi-node support (sharding the model, expert-parallel strategies, etc.) can be removed or bypassed for a single-machine deployment.
+
+* **Language and Documentation Barriers:** Parts of the original DeepSeek project documentation and comments are in Chinese (Mandarin). For example, the company background and some release notes appear only in Chinese. Important insights – like the value of model **distillation for local deployment** – are described in Chinese text. One such note translates to: *“Through knowledge distillation, DeepSeek-R1 provides a low-hardware-cost local deployment solution – its greatest contribution to the public. DeepSeek-R1 doesn’t need to outperform OpenAI’s models; it just needs to be good enough and affordable. As shown in the table, an ordinary personal computer can successfully deploy the 1.5B distilled model, which is compact and economical, offering a new idea for AI’s future development.”*. We need to **translate and integrate such insights into our design**. Any Chinese-only content in the repository will be translated to clear English so that all developers can understand it. This ensures that documentation is not an inefficiency; instead, everyone can learn from the original authors’ notes and rationale.
+
+**Summary of Challenges:** In its current form, DeepSeek is a cutting-edge but unwieldy system for our goals. It provides top-tier performance, yet at the cost of size and complexity that are impractical for a self-contained laptop app. **Our mission is to extract the essence of DeepSeek – its reasoning capability and useful features – and repackage them in a lightweight, transparent form.** We will leverage the existence of **smaller distilled models** from DeepSeek (ranging from 1.5B to 32B parameters) as a starting point. These distilled models (based on Llama and Qwen) offer *“an economical local alternative”* to the giant model, with the smallest (1.5B) being ~1.1 GB in size. A 1.5B or 7B model can fit in 16 GB RAM (especially with quantization), so this is a feasible path for the MVP.
+
+In short, **the existing DeepSeek provides inspiration and pre-trained weights, but we will re-architect it for simplicity.** By cutting out distributed training logic, limiting context sizes, and translating all documentation to English, we eliminate the major inefficiencies for our use case. The next sections outline a phased plan to achieve this.
+
+## System Architecture Overview (Target Design)
+
+Before diving into the roadmap, here is a **high-level architecture** for the envisioned local-first DeepSeek system:
+
+* **Model Core (LLM Engine):** A local language model that can be loaded and run on CPU (with optional GPU acceleration if available). For the MVP this will likely use a **distilled DeepSeek model** (e.g. the Qwen-7B or Llama2-7B variant distilled from DeepSeek-R1) running via an existing library (such as Hugging Face Transformers in Python). The model core will have a simple interface, e.g. `generate_response(prompt, max_tokens) -> text`. Initially, this might be a Python wrapper, but the interface will be designed to allow a Rust-based implementation later (for example, using Rust bindings or a Rust-native inference library in Phase 2+).
+
+* **Context Memory (SQLite Database):** We will use SQLite as a lightweight local database to store context and intermediate data. This serves multiple purposes:
+
+  * Store conversation history (user questions and AI answers) in a structured form, with timestamps or session IDs. Instead of relying on the model’s 128K context window, we will retrieve relevant past dialogue from the DB when needed (enabling long conversations without feeding the entire history every time).
+  * Store cached results or embeddings for documents. For instance, if the user provides a document to the AI, we can store its processed representation (e.g. embeddings or a summary) in SQLite. This **caching** means repeated queries on the same document or knowledge base can be answered faster.
+  * Store configuration or user preferences (e.g. a setting for maximum allowed tokens, or toggling certain features). This makes the system self-contained (no external config server needed) yet easily queryable.
+
+* **Orchestration & API Layer:** The logic that connects everything: it will accept user input (question or instruction), manage the workflow, and produce the answer. Steps may include:
+
+  1. **Input Processing:** Clean or truncate the user input if needed. Possibly perform keyword extraction or embedding generation for the input to help retrieve context.
+  2. **Context Retrieval:** If the conversation or knowledge base is large, query the SQLite DB for relevant entries. For example, fetch the most recent N exchanges or use an embedding similarity search (could be a simple cosine similarity done in Python or Rust) to find which past chunks are related to the question. This retrieved context is then appended to the prompt.
+  3. **LLM Inference:** Formulate the final prompt (including retrieved context, if any, plus the user’s query) and call the **Model Core** to generate a response. We will use a smaller context window (initially perhaps 2048 tokens) to ensure fast inference. If the assembled prompt is too long, the system will **automatically truncate or summarize** parts of it and issue a warning (so the user knows some context was dropped).
+  4. **Output Processing:** The raw model output may be post-processed (e.g. trim excessive whitespace, ensure JSON validity if we expect structured output, etc., depending on use-case). Also, the new interaction (user query and answer) is saved into the **Context Memory (SQLite)** for future retrieval.
+  5. **User Alerting:** If any limits were hit (for example, context was too large and got cut, or model had to shorten the answer due to token limit), the system should notify the user. This could be as simple as an in-text note or a console warning like: “⚠️ Note: Context truncated because it exceeded memory limits.”
+
+* **Logging & Monitoring:** Throughout the process, the system will log key events and metrics. This includes timestamps, lengths of inputs/outputs, any warnings (like memory usage spikes or long runtime for a query), and errors. In the MVP, logging can be to the console or a log file using Python’s logging module. In later phases, this could be made more sophisticated (structured logs, maybe a small dashboard or at least clear log files for analysis). The logs are crucial for validating performance and spotting when we need to optimize further.
+
+The diagram below summarizes the flow:
+
+**User Input → (Process Input & Check DB) → Retrieve relevant context from SQLite → Combine into prompt → LLM generates answer → Post-process answer → Return answer to User (and save Q&A to SQLite)**
+
+*(This text representation serves as our architecture diagram given the text format.)*
+
+Crucially, this architecture is **modular**. Each piece (input processing, DB, LLM, output post-processing) can be developed and tested in isolation. The interfaces will be kept simple (e.g., a function to query context, a function to run the model) so that we can **swap implementations easily**. For example, the LLM engine might be Python-based at first, but in a later phase we could replace it with a Rust module (providing it adheres to the same interface). Similarly, if we outgrow SQLite, we could substitute a more scalable database or in-memory store with minimal changes to other components.
+
+Having outlined the target system, we now break down the **phased roadmap** to build it, with increasing capability at each phase.
+
+## Phased Roadmap
+
+We propose to develop the local-first DeepSeek in **three main phases**, each with specific deliverables and success criteria. Each phase builds upon the previous one, adding improvements or new features in a controlled manner. We start with a minimal viable product to validate the approach, then incrementally optimize and extend it.
+
+### Phase 1: Minimal Viable Local Model (MVP)
+
+**Objectives:** Establish a working prototype of the system that can answer user queries locally. This phase focuses on **simplicity and correctness**: get the basic pipeline running end-to-end on the laptop, using a small model and straightforward implementations. Performance will be limited in Phase 1, but that is acceptable; the goal is to create a solid, well-understood foundation we can iterate on.
+
+**Scope and Features (Phase 1):**
+
+* **Model & Inference:** Integrate a **small pre-trained model** that is compatible with DeepSeek’s approach. We will likely use one of the **DeepSeek-R1 distilled models** for this purpose (e.g. the 1.5B or 7B Qwen-based model) because they are known to run on modest hardware. The model will be loaded via Python (using HuggingFace Transformers or an equivalent library) for simplicity. We will verify that the model can generate text on the CPU within reasonable time (for example, ~a few tokens per second is acceptable for MVP). If the distilled models are not readily available, as a placeholder we could use an equivalently sized open model (like LLaMA-2 7B) to ensure our pipeline works, then swap in the DeepSeek-distill weights when obtainable.
+
+* **Prompt & Response Flow:** Implement the basic prompt construction and response handling. For MVP, we can keep this simple: the prompt may just be the user’s last question and possibly a fixed system instruction (e.g. “You are DeepSeek Assistant, answer clearly…”) without complex context retrieval yet. We will ensure the system takes a user’s input text and returns the model’s output text successfully.
+
+* **SQLite Context Store:** Set up a SQLite database file to persist conversation history. In Phase 1, the usage can be minimal: after the model generates an answer, we store the **prompt and response** in a table (with fields like `id, timestamp, user_message, assistant_answer`). This confirms we can write to and read from the local DB. We will also implement a simple **retrieval function** (e.g. fetch the last N exchanges) to prepare for using context. Initially, we might always retrieve just the immediate last Q&A pair to include as context (simulating a short memory). This can evolve later.
+
+* **User Interface:** In MVP, the UI can be very simple – even a console application or REPL where the user types a question and gets an answer. The focus is the backend, but to test end-to-end we’ll have a basic CLI loop. (In a production version we might build a GUI or web interface, but that’s out of scope for now. We’ll concentrate on the core logic.)
+
+* **Documentation & Clarity:** As we implement Phase 1, we will write **extensive comments and documentation**. This includes:
+
+  * Clear README describing how to set up and run the prototype.
+  * Inline comments explaining each part of the code in plain English (for example, explaining what a function does and why it’s needed in simple terms).
+  * A glossary in the documentation for any DeepSeek-specific terms (e.g. explaining what *“Mixture-of-Experts”* means conceptually, even if our MVP doesn’t fully use it). This is to ensure a layperson or a new developer can understand the context and purpose of each component.
+
+* **Layman Explanation Example:** We plan to include comment blocks or docstrings that provide layman analogies. For instance, before the code that retrieves past Q&A from SQLite, a comment might read: *“// We check our ‘memory’ for relevant info. This is like looking at previous conversations to avoid repeating ourselves or to continue the same topic.”* Such explanations make the code more approachable to non-ML experts.
+
+* **Resource Limits & Warnings:** In this initial phase, we will implement **basic safeguards** for resource limits:
+
+  * Set a **maximum input length** (maybe start with 1000 tokens) and **maximum output length** (e.g. 512 tokens) for the model. If the user’s question is too long (exceeds the limit), the system will refuse or summarize it rather than attempting to process it fully. This threshold will be documented and also coded as a check at runtime.
+  * Monitor memory usage in a rudimentary way. Python doesn’t easily give total memory, but we can estimate by input size and model size. For example, if the user tries to load a much larger model than 16 GB can handle, we detect the model’s size (if known) and print a warning or prevent it. Similarly, if we accumulate a lot of chat history in SQLite, we won’t load it all – we’ll only load the recent few entries by default.
+  * Timeouts: If using library calls that could hang or be very slow (like generation), we will document how to stop the process if needed (and in Phase 2 consider adding an actual timeout mechanism).
+
+**Sample Pseudocode (Phase 1)** – illustrating how components interact:
+
+```python
+# Pseudocode for main loop
+model = load_model("deepseek-distill-1.5B")  # Load the small model (with proper error handling if too large)
+init_database("conversation.db")             # Set up SQLite and ensure table exists
+
+print("DeepSeek Assistant is ready!")
+while True:
+    user_input = input("You: ")
+    if not user_input:
+        break  # exit on empty input for example
+    
+    # Basic context retrieval: get last exchange (if any)
+    history = db_fetch_last_n(n=1)
+    prompt = compose_prompt(user_input, history)  # maybe just concatenates for now
+    
+    # Check length of prompt to avoid too long
+    if len(tokenize(prompt)) > MAX_TOKENS:
+        warn_user("Input too long, truncating or summarizing context...")
+        prompt = truncate_prompt(prompt, MAX_TOKENS)
+    
+    # Generate response
+    response = model.generate(prompt, max_tokens=MAX_OUTPUT_TOKENS)
+    
+    print("Assistant:", response)
+    db_save_interaction(user_input, response)
+```
+
+*(Note: The actual implementation will use proper tokenization and might include special tokens or format as needed by the model. The pseudocode above omits those details for clarity.)*
+
+This snippet shows a loop reading user input, preparing a prompt, generating a response, and saving the interaction. Even at this stage, we include a check on prompt length and call `warn_user` (which could simply print a caution message). The **`db_*` functions** wrap SQLite operations – these will be implemented in a separate module/file, making it easy to maintain or swap out later.
+
+**Success Criteria (Phase 1):**
+
+We will consider Phase 1 complete when the following are achieved:
+
+* ✅ **Basic Q&A Works:** The system can answer questions locally in a conversational manner. For example, if the user asks “What is DeepSeek?”, the assistant should produce a coherent answer (drawn from the knowledge encoded in the model). It’s acceptable if the knowledge is limited by the small model; we mainly want to see that the pipeline produces *some* reasonable output without errors.
+* ✅ **Local Resources Suffice:** Running a query should not crash the laptop. Specifically, memory usage stays within limits (e.g. below ~16 GB; ideally well below to allow OS overhead). We should be able to run a few questions in a row and the system remains stable. If the model load or first query is slow (e.g. taking 30 seconds or 1 minute), that’s tolerable for MVP, but it should not grow unbounded with each interaction.
+* ✅ **Data Persistence:** The conversation history is successfully stored in SQLite and can be inspected. For example, after a few Q&A's, the SQLite file should contain those records. We can verify by running a simple SELECT query on the DB or via our `db_fetch_last_n` function returning expected results.
+* ✅ **Documentation & Clarity:** The code repository at this stage should be well-organized and documented. We will have a README explaining how to set up and run the prototype. Key modules (like `model.py`, `database.py`, etc.) will have top-of-file comments describing their purpose. We will ask a colleague or a developer not involved in the project to read the docs/code and see if they can understand the system’s high-level workings. If they can grasp it (or if our supervising engineer gives a green light on clarity), we have met the explainability goal for Phase 1.
+* ✅ **Layman Explanation Included:** At least one portion of the documentation (or inline comments) will be explicitly written for a lay audience. For instance, an introduction section in the README might explain what a language model is and how our system uses it, without assuming ML knowledge. Success is when a non-ML coworker can read that and say “I get the basic idea of what this does.”
+* ✅ **No Chinese Text Left Untranslated:** Any Mandarin comments or notes found in the forked DeepSeek code or docs are translated to English in our documentation. We will double-check that the user doesn’t encounter any Chinese-only content in the delivered MVP. (If the original model repo had, say, a Chinese README, we will have incorporated the needed info into our English documentation by now.)
+
+By meeting these criteria, we ensure that the MVP provides a solid base: it works on the target hardware, is understandable, and sets the stage for performance improvements next.
+
+### Phase 2: Performance Optimization and Rust Integration
+
+**Objectives:** In Phase 2, we address the **performance bottlenecks** identified in the MVP and start integrating **Rust** to improve efficiency and robustness. The aim is to make the system faster and more scalable *without* sacrificing clarity. We will replace or augment some Python components with Rust implementations (or Rust libraries) where it makes sense. This phase will also introduce more advanced caching and context management, leveraging SQLite and possibly other data structures to handle larger contexts intelligently.
+
+**Key Improvements (Phase 2):**
+
+* **Identify Bottlenecks:** First, we will use the MVP to profile runtime and resource usage. Likely bottlenecks include:
+
+  * *Inference Speed:* Generating responses token-by-token on CPU can be slow. Python overhead (GIL, etc.) might further reduce throughput.
+  * *Tokenization and Data Processing:* If we tokenize text or do embedding similarity in pure Python, that could be slow for large texts.
+  * *Context Retrieval Logic:* As we start to incorporate more of the conversation history or documents, searching through them (even in SQLite) might become slow if done suboptimally (e.g. a naive linear scan in Python).
+  * We’ll use Python’s profiling tools or simple timing logs around sections to quantify these. For example, log how long `model.generate()` takes for a 100-token output, how long it takes to fetch context from DB of size N, etc.
+
+* **Rust for Tokenization and Text Processing:** One immediate win is to handle text processing in Rust. We can use or build a Rust library for **tokenization** (converting text to tokens and back). Many modern tokenizers (like BPE for GPT models) have implementations in Rust which are much faster than Python equivalents. We will wrap a Rust tokenizer library (or write a small one if needed) and expose it to Python (using PyO3 or a C API) so that when our Python code needs to tokenize or count tokens, it actually calls the fast Rust code. This will speed up prompt length checks, truncation, etc., and serve as a first example of Rust integration.
+
+* **Rust-based LLM Inference (Prototype):** We will explore using Rust for the core model inference. There are a couple of approaches:
+
+  * Use an existing Rust binding to frameworks (e.g. **`tch-rs`** which is a Rust binding to PyTorch, or **`ggml`** via Rust to load a GGML quantized model). For instance, we could try converting the 7B model to a ggml format (used by projects like llama.cpp) and then use a Rust crate to run it. This could dramatically improve CPU utilization by leveraging multi-threaded C/C++ under the hood, and possibly reduce memory via quantization (running the model in 4-bit or 8-bit precision).
+  * Alternatively, use Rust to offload parts of generation. For example, keep using the Python model, but have Rust handle the **sampling** step (where it picks the next token) or other compute-heavy loops. However, this might be more complicated than a full Rust pipeline.
+
+  We will attempt a proof-of-concept where a question is answered completely outside of Python: e.g. a small Rust program (or module) loads a model and generates text. If successful, we can integrate that into our system (perhaps behind a feature flag or option). If not fully ready to replace Python model, we might still manage to use Rust for specific heavy operations in the generation loop (like vectorized math on logits). The justification for this effort is that **Rust can provide lower-level optimization and better multi-core usage** than Python, especially avoiding Python’s GIL for parallelism. Even if the underlying math libraries are in C/C++ (as in PyTorch), a Rust-driven approach might simplify deployment (no Python interpreter overhead) and give us more control over memory.
+
+* **Improved Caching & Context Use:** In Phase 1 we only took the last interaction for context. In Phase 2, we will extend this:
+
+  * Implement a simple **vector embedding** for text chunks and store those in the SQLite DB (as blobs or in a separate table). We can use an open-source embedding model (like a small sentence-transformer) to convert text to a vector. Then, for a new query, we compute its embedding and quickly find the most similar past chunks (using a cosine similarity search). This retrieval can be done in Rust for speed: for example, writing a Rust function to scan through stored vectors and compute similarities using multiple threads (for many stored items) would be far faster than doing so in Python. This is an ideal Rust integration point: **computationally heavy, embarrassingly parallel, and safe from needing Python’s GIL**.
+  * Once relevant context items are found (e.g. the top 3 past Q&A that relate to the new question), we include them in the prompt. This lets us handle a much longer conversation or knowledge base **without exceeding the model’s input limit**, because we’re selecting only what’s needed. It effectively acts as a **cache** of knowledge: the model doesn’t need to re-derive answers it gave before, we can just remind it of them.
+  * We will also incorporate a **response caching** mechanism. If the user asks an identical question to one asked before, the system can fetch the stored answer from SQLite instead of generating it again. This is a simple lookup by normalized query text. (We’ll document that this is an exact match retrieval – Phase 3 could explore semantic similarity for questions to handle paraphrased repeats.)
+
+* **Concurrency and Multi-threading:** With Rust components coming in, we can use threads more freely. For example, the SQLite operations can be offloaded to a separate thread or Rust async task so that they don’t block the main loop. If generation is still in Python, we can’t easily multi-thread that due to GIL, but if we move generation to Rust or an external process, we could then use multiple threads (e.g. allow multiple questions to be processed in parallel or stream output tokens as they come). In Phase 2, a stretch goal is to enable **streaming output**: instead of waiting for the full answer to be ready, start printing tokens as they are generated. This improves the user experience for long answers. Achieving this likely requires Rust or careful Python threading (to avoid locking up the input loop). We will attempt this primarily if we have a Rust-based generation, which can callback or yield partial outputs.
+
+* **Enhanced Logging & Monitoring:** Expand the logging from Phase 1. Now that we have performance improvements, we should quantify them:
+
+  * Log the time taken for each major step (DB retrieval, model inference).
+  * If Rust components are used, ensure they log errors or important info back to a common log (perhaps via calling Python logging or writing to stdout which we capture).
+  * Implement a simple **memory usage check** if possible. For instance, in Python we can use `psutil` to get process memory and log it after generation. In Rust, we can occasionally check memory too. The system can produce a warning if memory usage exceeds, say, 80% of available RAM. This would alert the user that they are near the limit (and perhaps suggest using a smaller model or restarting the session).
+
+**Justification of Rust Integration:** By the end of Phase 2, we expect tangible benefits from introducing Rust:
+
+* Faster text processing (tokenization, similarity search) – possibly an order of magnitude faster for large texts versus pure Python.
+* More efficient use of CPU cores during generation if we succeeded in Rust-based inference. For example, running a 7B model in 4-bit might go from ~1 token/sec in Python to ~5+ tokens/sec in a highly optimized Rust/C++ environment (this is speculative, but given projects like llama.cpp achieve several tokens/sec on CPU for 7B, it's reasonable).
+* Reduced latency for context heavy queries, as we only pass the model what’s needed and do heavy filtering in native code.
+
+We will document these improvements. For instance, in the PRD or subsequent progress report, we might show: *“Question X took 15 seconds in Phase 1, and 5 seconds in Phase 2 after optimizations.”* Similarly, *“We were able to increase the number of relevant history messages considered from 1 to 5, without slowing down response time, by using Rust for retrieval.”*
+
+**Success Criteria (Phase 2):**
+
+* ✅ **Performance Gain:** The system is measurably faster or more efficient than the Phase 1 version. For example, if a test question took 30 seconds to answer in Phase 1, it now takes maybe 15 seconds or less in Phase 2. Or if Phase 1 could handle at most a 500-token prompt before lagging, Phase 2 can handle, say, 2000 tokens comfortably. We will set a specific target once Phase 1 profiling is done (e.g. *“aim to double the tokens/sec generation rate”* or *“reduce overall latency by 50% for a representative query”*). Meeting that target will be a success indicator.
+* ✅ **Rust Module Implemented:** At least one core component is now powered by Rust. This could be the tokenizer or the similarity search or the model runner. The criterion is that we have Rust code in our repository that compiles and is used in the pipeline, and it has proper integration (with documentation for how to build it, and fallbacks if any). We should also have tests for the Rust component to verify it produces identical results to the old Python version (for example, a test that tokenizing a sample sentence via Rust yields the same tokens as the Python tokenizer did).
+* ✅ **Caching & Context Retrieval:** The system now intelligently uses context. A success scenario: ask the assistant a question, then ask a follow-up that requires remembering the previous answer. The assistant should use the stored context to respond correctly to the follow-up, rather than acting as if it’s a new conversation. We can demonstrate this in a simple conversation transcript. Also, if we ask the *exact* same question twice, the second time should be near-instant (retrieved from cache) – we will log and observe that behavior.
+* ✅ **Resource Warnings:** Intentionally push the system near its limits to see if warnings trigger. For example, feed in a very long text as input (maybe by pasting a few pages of text) and confirm that the system does not attempt to process it fully but instead warns “Input too long” or similar. Alternatively, try loading a slightly larger model than advisable and see if the system stops with a clear message like “Model too large for available memory.” These checks ensure our user-protection mechanisms are working.
+* ✅ **Maintainability:** Even though we added Rust code, the system remains clear and maintainable. Success here means:
+
+  * The Rust code is well-documented (with comments in English) and its purpose is explained in the main README or design docs.
+  * Other developers can build the Rust component easily (we provide a script or `Cargo.toml` instructions, etc., so it’s not a hurdle).
+  * We haven’t introduced obscure bugs – test coverage of critical logic (both Python and Rust) should ideally be improved in Phase 2. We will add unit tests especially around new pieces (e.g. test the DB retrieval function with a fake dataset, test the tokenizer on known inputs, etc.).
+* ✅ **Demonstration-Ready:** By end of Phase 2, we expect the system to be robust enough to demo to stakeholders (e.g. an internal meeting or the employer’s review). That means it can handle a variety of questions in a row, leverage context, and not crash during a short demo session. We should be confident to show off, for instance: asking a math question (to show reasoning), asking a coding question (to show some versatility), and a follow-up question (to show context memory), all working smoothly.
+
+Phase 2 sets the stage where we have a nicely optimized, semi-professional version of the local DeepSeek. The final phase will then focus on further scaling and fine-tuning for even better capabilities and possibly removing remaining dependencies.
+
+### Phase 3: Scaling Up and Extended Capabilities
+
+**Objectives:** In Phase 3, we will refine the system for **better scalability, flexibility, and completeness**. This involves possibly supporting larger models (if needed), further replacing Python components with Rust (aiming for a predominantly Rust-based backend), and adding any features necessary for a **production-ready local AI assistant**. We also plan forward-looking enhancements such as more robust evaluation and safety checks.
+
+**Key Enhancements (Phase 3):**
+
+* **Optional Larger Model Support:** With the optimizations in place, we can test using a bigger model (if beneficial). For example, trying a 13B or 20B parameter model (one of the larger distilled checkpoints) if the hardware allows. Thanks to caching and context trimming, we might handle these in 16 GB RAM by using 4-bit quantization. We will make the system flexible: allow the user (or developer) to choose which model to load. This could be a command-line argument or config (e.g. `--model deepseek-distill-7b` vs `--model deepseek-distill-1.5b`). We’ll document the trade-offs (bigger model = better answers but slower and more memory). The key is that our architecture can accommodate it if needed (since we designed modularly, just swapping the model path should work, as long as it fits in RAM). We also ensure that if a user tries a too-large model, the system recognizes it and either refuses or suggests alternatives (preventing a crash).
+
+* **Full Rust/Python Integration or Bypass:** By Phase 3, we envision the critical path (from user input to model output) to rely little on Python. Ideally:
+
+  * The entire generation pipeline could be moved to Rust, possibly resulting in a single compiled binary for the backend. We might still use Python for high-level scripting or the UI, but the heavy lifting could be in Rust.
+  * Alternatively, we create a Rust **library** that encapsulates model inference, caching, and retrieval, and Python simply calls this library. This way, Python becomes just a thin wrapper (or could even be dropped if we provide a CLI in Rust).
+  * If feasible, we will attempt to integrate the Rust components in such a way that we can run the system in two modes: (a) **development mode** with Python (easier to debug, tweak prompts, etc.), and (b) **standalone mode** with a Rust binary (for deployment or sharing with others without requiring a Python environment). Success would be having a `deepseek_local.exe` (on Windows) that one can run and get the assistant prompt, with all features working and no Python dependencies. This is ambitious, but Rust’s portability makes it possible if we manage to implement all needed pieces in Rust. Key tasks to achieve this:
+
+    * Use a pure Rust inference engine (through libraries or our own code) for the model. If in Phase 2 we only partially did this, Phase 3 would complete it. We may use community projects or optimize our own.
+    * Use Rust for database operations as well. We might stick with SQLite via `rusqlite` crate in Rust. This ensures the DB and retrieval logic are fully under Rust control. (If we had a Python dependency for SQLite in earlier phases, we’ll replace it.)
+    * Implement any utility like configuration parsing or logging in Rust.
+    * Provide a simple CLI in Rust for user interaction (perhaps leveraging Rust’s `crossterm` or similar for a nice console UI).
+    * Ensure all these compile into one program.
+
+  Even if we don’t drop Python entirely, having a Rust-centric path will improve performance and reliability (no GIL issues, easier multithreading, and possibly lower memory overhead). If we have a Rust-based generation, this will also ease cross-platform packaging (just share the binary and model weights). The user won’t need Python or the myriad dependencies that might make install painful.
+
+* **Scalable Caching Logic:** Thus far we used SQLite for everything, which is fine for a single user on one machine. In Phase 3, we consider future scalability:
+
+  * Design the caching layer to be **abstracted** such that we could swap SQLite with a server-based solution if needed (for example, if in the future multiple devices or sessions should share context, or if we simply have more data than comfortable for SQLite). We will introduce an interface or at least documentation on how to move to something like PostgreSQL or a vector database if needed. Perhaps implement a toggle: if the DB grows beyond X size, suggest using an external DB.
+  * Optimize the SQLite usage for larger data: add indexes to key columns (like on an embeddings table if we query by similarity threshold, etc.). Ensure we parameterize queries to avoid SQL injection if user input is involved (just good practice).
+  * If the context data (conversation + docs) becomes very large (say thousands of entries), our Rust similarity search might become the bottleneck. In that case, Phase 3 could integrate a proper approximate nearest neighbor (ANN) search library for vectors (many exist in Rust and C++). This would let us retrieve relevant context in sub-linear time even from huge archives. We’ll only consider this if we foresee a need (i.e. if in testing we loaded a lot of data and retrieval got slow). It’s a placeholder for scalability.
+
+* **User Experience Improvements:** Add more polish to how the system interacts:
+
+  * **Interactive Controls:** Perhaps add commands like `!reset` to clear conversation, `!history` to print recent conversation from the DB, etc., to make the CLI more user-friendly.
+  * **Output formatting:** Ensure the assistant’s answer is well-formatted (we might integrate markdown support if needed, since some model answers might contain markdown or code).
+  * **Safety Filters:** Although not heavily stated in previous phases, as we near a user-ready product, consider adding basic content filters. For example, if the model output is detected to be extremely long or maybe if it contains some unwanted content, we could intercept. This could be a simple regex or keyword check for phase 3 (just to prevent, say, crazy outputs that could fill the screen or something malicious). The focus is not on censorship, but on practicality (like preventing huge dumps that freeze the UI).
+  * **Validation Mode:** Provide a way to run the system in a “validation/test” mode where it runs through a suite of sample queries (possibly with known answers or at least known behaviors). This helps in final testing to ensure new changes didn’t break basic functionality. For example, an automated script could ask the assistant 5 fixed questions and record the responses, mainly to ensure each step executes without error and within a time budget.
+
+* **Evaluation and Benchmarking:** By Phase 3, we want to measure how well our local DeepSeek performs both technically and functionally. We will:
+
+  * Compare some of its answers to known results from the original DeepSeek (if available) or to other models. While we don’t expect a 7B model to match a 671B model, we can at least ensure it’s in a reasonable range for things like math or logic puzzles (given R1-distill models were reported to achieve strong results for their size). If we find shortcomings, we might adjust the prompt strategy or note them as limitations.
+  * Profile memory and CPU under heavy usage to ensure stability. If, say, a user loads a 10MB text into context and asks questions, does the system handle it gracefully (maybe by summarizing or chunking internally)? We will simulate worst-case scenarios to test our design assumptions.
+  * Define success criteria in terms of *throughput*: e.g. the system should support at least **X** questions per minute on average without failing. Or it should handle a conversation of **Y** turns without degradation.
+
+**Success Criteria (Phase 3):**
+
+* ✅ **Robustness:** The system runs reliably for extended sessions. For instance, one could have a 30-minute Q&A session with the assistant with various questions without needing to restart or encountering crashes. Memory usage should remain roughly steady (it may go up initially when loading model, but it shouldn’t continuously climb with each answer due to leaks).
+* ✅ **Predominantly Rust Implementation:** We have either a working standalone Rust binary or at least all critical components available in Rust. If a full Rust binary is built, that’s a clear success (we can show two ways to run the assistant: via Python or via the compiled binary). If not full, then at minimum the **model inference, tokenization, and context search are handled by Rust code**, with Python only orchestrating. Essentially, if we disable the Python, the core should still function. This will be verified by running our internal tests through the Rust interface and ensuring outputs match.
+* ✅ **Scalability & Performance:** The system should gracefully handle larger loads than before. For example, we could load a few hundred Q&A pairs into the DB and still answer questions quickly (with relevant ones retrieved). Or we switch to a 13B model and still get responses in an acceptable time (maybe 2-3x slower than 7B, which is expected, but still practical). We can set a target like: *“Even with 1000 context entries stored, retrieval + answer generation stays under 10 seconds for a typical question.”* and *“Switching from 7B to 13B model does not break the system, and a simple factual question can still be answered in under 20 seconds.”* If these hold true, we meet scalability needs for a personal assistant scenario.
+* ✅ **User Warnings and Guidance:** All mechanisms to warn the user about limits are in place and refined. By Phase 3, not only do we warn, but we might also **suggest solutions**. For example, if context is too large, the warning might say *“Context truncated. Consider rephrasing or summarizing your input.”* If memory is low, maybe *“Memory nearly full: consider using a smaller model or restarting the session.”* Essentially, the assistant should be somewhat self-aware of its running constraints and inform the user proactively. We’ll test scenarios to confirm these messages appear at appropriate times and are understandable.
+* ✅ **Thorough Documentation & Handoff:** The PRD will be finalized with actual implementation details, and a separate **Technical Documentation** document might be produced (or an updated README) that reflects the final state. It should cover how the system works, how to build and run it in both modes, and all the features and limitations. Success here is if a new developer (or the employer) can read the docs and feel confident to use or modify the system. We will include architecture diagrams or flowcharts as needed (since now the design is stable).
+* ✅ **Validation Tests Pass:** We’ll have a suite of tests (could be a mix of automated and manual scripts). For instance, a test that queries something trivial and expects a certain format (not exact text, but that an answer is produced and not an error). Also tests for the caching: ask same question twice and ensure second time is faster (cache hit). If we have these, they should all pass consistently before we call Phase 3 done.
+* ✅ **Employer Presentation Approved:** Since this should be suitable for an employer presentation, we’ll do a final review/dry-run of demonstrating the system. We anticipate showing:
+
+  * The clarity of the code (maybe on GitHub or an IDE, highlighting the neat modular structure and comments).
+  * A live demo of the assistant answering questions, showing off context memory (like asking a question about a topic, then a follow-up, to show it remembers).
+  * Possibly showing performance numbers or how Rust improved things (e.g. a small comparison chart we can speak to).
+  * If the employer and team find this satisfactory (i.e., we meet their expectations for a local AI assistant that’s explainable and efficient), then the project is a success.
+
+Each phase of this roadmap builds towards a **local-first DeepSeek system that is easy to iterate on**. By following this phased approach, we mitigate risks: we start simple to ensure we understand everything, then optimize critical pieces with Rust and better algorithms, and finally harden the system for real-world use. The end result will be a **simplified DeepSeek** that retains the spirit of the original (powerful reasoning on a local machine) while being **accessible, documented, and efficient** for an individual developer.
+
+## Logging and Validation Strategies
+
+Throughout development, we will employ rigorous logging and validation to ensure the system behaves as expected and to catch issues early:
+
+* **Detailed Logging:** We will maintain a consistent logging approach (likely using the Python `logging` module for Phase 1 and integrating with Rust’s logging in later phases). All major actions will be logged at INFO level, and debug details at DEBUG level. For example:
+
+  * When a user query is received, log its length (in tokens) and perhaps a preview of the content.
+  * When context is retrieved from SQLite, log which entries were fetched (maybe their IDs or a snippet) and why (e.g. similarity scores).
+  * Before calling the model, log the final prompt size and maybe the first few tokens (to trace that context injection worked).
+  * After generation, log the time taken and the number of tokens generated.
+  * If any warning condition occurs (length truncated, memory high, etc.), log that with WARNING level.
+  * Rust components will use a compatible logging (for instance, using `env_logger` or similar in Rust and piping output to the main log). We will test that Rust messages appear properly.
+
+  We’ll also ensure logs are timestamped, so we can analyze performance timelines.
+
+* **Validation Tests (Continuous):** As we develop each feature, we will write small tests or scripts to validate it. Some of these include:
+
+  * **Unit Tests:** e.g. test the tokenizer separately (does “Hello, world!” tokenize to expected tokens?), test the DB functions (insert and retrieve a dummy entry), test the prompt composer with a known history to see if formatting is correct.
+  * **Integration Tests:** Simulate a full round-trip: feed a known prompt to the system and observe the output. While we might not know exactly what the model will answer, we can at least ensure an answer is produced and check things like it’s not empty, or that if we ask a question twice the second answer comes from cache (we can detect that by a special log message or a time threshold).
+  * We’ll automate these where possible (maybe using `pytest` for Python parts, and Rust’s `cargo test` for Rust parts). The goal is to catch regressions quickly – e.g., if in Phase 2 the Rust tokenizer accidentally segments text differently than the Phase 1 Python did, a unit test would highlight the discrepancy.
+
+* **Performance Benchmarks:** We will maintain a few benchmark scenarios to track performance improvements:
+
+  * For instance, a fixed prompt of 100 tokens and measure how many tokens per second the system generates in each phase. We expect an improvement in Phase 2, and we’ll record those numbers.
+  * Another benchmark: loading a context of N entries and measuring retrieval time. We can artificially populate the DB with, say, 1000 dummy entries and time the similarity search. This will guide if we need more advanced indexing in Phase 3.
+  * Memory usage will be observed by external tools or psutil. We might include a test that says “load model, run one query, ensure memory used < X MB” as a guard.
+
+* **User Acceptance Testing:** Because one of our criteria is layman-level clarity, we will have a non-developer or junior developer try the system with a guide. They should be able to:
+
+  * Run it following our README (this validates that our instructions and setup are correct).
+  * Ask a few questions and get answers (validating the functionality).
+  * Read the documentation or code comments to explain back what’s happening. If they struggle, we’ll refine the explanations.
+
+  Their feedback will be invaluable to fine-tune the user-facing aspects (like error messages clarity, documentation, etc.). We plan this especially before finalizing Phase 3.
+
+* **Issue Tracking and Iteration:** We will keep track of any bugs or inefficiencies discovered (e.g. if during testing we find a memory leak or a case where context retrieval picks irrelevant text). Using a lightweight issue tracker (even GitHub issues or a simple TODO list) ensures we don’t forget to address them. Each phase’s end criteria includes resolving known critical issues from the previous phase.
+
+* **Validation of Parity with DeepSeek Features:** While we cannot match the full power of 671B DeepSeek, we want to ensure we haven’t lost core features like *reasoning capability*. We will test the system on a few reasoning tasks (e.g. a simple math word problem, a code generation prompt, etc.) and see if the chain-of-thought or results are sensible. If the distilled model struggles, that’s expected to some degree, but we might adjust our prompting (maybe add a “let’s think step by step” prompt if needed to coax reasoning, as DeepSeek-R1 specialized in reasoning). Our validation includes trying such techniques and confirming the model’s outputs improve. This way, we keep the “spirit” of DeepSeek (reasoning, verification, etc.) alive in our version as much as the small model allows.
+
+In summary, by logging extensively and validating at each step, we ensure that by the end of Phase 3 we have a **trustworthy and transparent** system. Not only will it work well, but we’ll also have the data and tests to prove why and how it works. This will be crucial when presenting the final product to the team or stakeholders – we can demonstrate not just the functionality but the process by which we tested and guaranteed the quality of each component.
+
+## Rust Integration Opportunities (Summary and Justification)
+
+*(This section recaps where and why we use Rust, as an easily referenceable list for stakeholders interested in the tech choices.)*
+
+While we have woven Rust usage into the roadmap, here is a clear breakdown of parts of the system that benefit from rewriting or wrapping in **Rust**, along with justification for each:
+
+* **Tokenization and Text Encoding:** Tokenizing text (splitting into subword tokens for the model) is computationally light per se, but doing it in Python for large texts (or many times) can add latency. By implementing tokenization in Rust (or using an existing Rust tokenizer library), we get **near C-speed** for this operation and can easily handle multithreading if needed (e.g. tokenize multiple pieces in parallel). This improves overall throughput, especially when preparing prompts or counting tokens for safety checks. It also eliminates potential discrepancies if we eventually move the model to Rust (we’ll use the same Rust tokenizer there).
+
+* **Vector Similarity Search:** Computing cosine or dot-product similarities between high-dimensional vectors (embeddings) is math-heavy (lots of multiplications and additions). In pure Python, this would be extremely slow for, say, hundreds of vectors of dimension 768. Rust, on the other hand, can perform these calculations **with optimized libraries or SIMD instructions**, and do it in multiple threads. By offloading embedding similarity search to Rust, we ensure that retrieving context from a large knowledge base remains fast (sub-second even for thousands of candidates). This is critical for scaling the system’s context without lag. Additionally, Rust’s strong memory safety guarantees mean we can handle large buffers of vectors with less risk of memory errors compared to manual C/C++ and without Python’s overhead.
+
+* **LLM Inference and Math Computation:** The core of the model – multiplying large matrices, applying neural network layers – is already done in optimized C/C++ (inside frameworks) even when called from Python. However, by moving to Rust we have a few advantages:
+
+  * We can integrate directly with libraries like `torch-sys` (for Torch C++ API) or use `ndarray`/`nalgebra` crates for custom implementations, gaining fine control. Or leverage community projects (like *ggml* through Rust bindings) that are designed for efficiency on CPU. This means we can tailor inference to our use case (e.g. use 4-bit quantization and only CPU threads, which some Python environments don’t support as cleanly).
+  * Removing the Python layer can reduce overhead in iterative generation. For example, generating one token at a time in a loop might involve a lot of Python back-and-forth; a Rust loop can run more smoothly. As a result, we expect **lower latency per token** and better usage of all CPU cores for matrix multiplications (since Rust can release the threads to do work uninhibited by the GIL).
+  * Rust is also an ideal place to implement any future custom ops. If we find we need a special algorithm (say, a custom attention mechanism or compression), doing it in Rust allows low-level optimizations and easy integration into our pipeline.
+
+* **Concurrency and Parallel Tasks:** Rust’s multi-threading is zero-cost (no global interpreter lock). We identified tasks like database access, file I/O, and possibly simultaneous user interactions as areas to exploit concurrency. For instance, with Rust we could handle a file upload and parse it into the DB in one thread while the model generates an answer in another. This would make the system more responsive. If we tried that in Python, we’d likely run into the GIL limitation or need complex multiprocessing setup. Rust makes these patterns easier and more reliable (data races are caught at compile time). So wrapping such concurrent logic in Rust and exposing a simpler interface to Python can drastically simplify the design while boosting performance.
+
+* **Standalone Deployment:** Packaging and distributing a Python project can be cumbersome (dependencies, environment issues), whereas a Rust program compiles into a single binary. By rewriting core pieces in Rust, we move toward a scenario where the entire application could be a single binary (plus the model weight files). This is a huge win for clarity and portability: an employer or any user can run the AI assistant by executing one file, without installing Python or other heavy frameworks. This also reduces the overhead (no need to load the Python interpreter, which itself uses memory and CPU). So, **rewriting the main loop and possibly CLI in Rust** yields an easier deployment. We justify this because the target environment is fixed (the user’s laptop); we don’t need dynamic scripting as much as a reliable service. Rust fits well for building a small “server-like” app that the user runs locally.
+
+* **Critical Safety and Performance Regions:** If there are any components where mistakes could be costly (e.g. memory management for large buffers, multi-thread synchronization for caching), Rust’s safety guarantees help eliminate entire classes of bugs (buffer overflows, data races). For example, if we manage an in-memory cache or do some manual memory mapping for the model weights, doing it in Rust ensures we won’t accidentally leak or corrupt memory – errors that could be catastrophic in a long-running process. Thus, rewriting such critical sections in Rust not only improves speed but also reliability and maintainability (no need to debug hard C++ segfaults or Python C-extension bugs).
+
+In conclusion, integrating Rust is not just about raw speed; it also aligns with our goals of clarity and modularity. Each Rust component will be written as a clear module with defined interfaces to the rest of the system. We will provide justification in documentation for each (e.g. “We use Rust for X because it makes Y 10x faster or uses memory more efficiently.”) By Phase 3, we anticipate the **majority of time-consuming tasks to be handled by Rust**, resulting in a system that is both **fast and robust** on our target hardware. This hybrid approach (Python for ease of use, Rust for heavy lifting) allows us to get the best of both worlds and is a modern best-practice for such applications.
+
+---
+
+**Sources & References:** (Preserved for transparency and further reading)
+
+* DeepSeek model details and performance characteristics, highlighting the scale and context length we adapt to our needs.
+* Hardware requirements for DeepSeek models, reinforcing why we focus on smaller distilled models for local use.
+* Insights from DeepSeek’s team on local deployment via model distillation, which guide our strategy for using 1.5B–7B models.
+* DeepSeek-R1 introduction and notes on reasoning capabilities – inspiration to maintain strong reasoning in our version.
+* (Additional references like technical blogs or library docs for Rust integration can be added as needed in documentation.)


### PR DESCRIPTION
## Summary
- add `copilot-instructions.md` with a roadmap for translating DeepSeek docs and rewriting heavy components in Rust

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bcd8b34588333861204cd3f05a7e8