### PR TITLE
Add module docs and simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,29 @@
-<!-- markdownlint-disable first-line-h1 -->
-<!-- markdownlint-disable html -->
-<!-- markdownlint-disable no-duplicate-header -->
+# Open Source LLM
 
-<div align="center">
-  <h1 style="font-size:"6rem"">🤖📖<br>🛠️💻</h1>
-  <sub><strong>Experimental Learning Fork</strong></sub>
-</div>
+## About This Fork
 
----
+This repository is a personal fork of the official [DeepSeek-V3](https://github.com/deepseek-ai/DeepSeek-V3) project. It exists to experiment with large language models in a local environment. The code is provided without any guarantee of stability or performance and is not intended for production use.
 
-<details>
-<summary><strong>About This Fork</strong></summary>
+**Important:** Use this repository at your own risk. For a stable and supported implementation, see the original [DeepSeek-V3 repository](https://github.com/deepseek-ai/DeepSeek-V3).
 
-This is a **personal fork** of the official [DeepSeek-V3](https://github.com/deepseek-ai/DeepSeek-V3) repository, created as a **learning project** to explore and experiment with large language models (LLMs) in local development environments. It is **not intended for production use** and comes with no guarantees of stability or performance.
+## Goals
 
-**⚠️ Important Warning:**
-This repository is a **side project** and should be used **at your own risk**. For stable, reliable, and officially supported implementations, please use the official [DeepSeek-V3 repository](https://github.com/deepseek-ai/DeepSeek-V3).
+- **Learning** – explore the inner workings of LLMs and their deployment.
+- **Experimentation** – try optimizations for lightweight, local usage.
+- **Community Contribution** – share findings with other developers.
 
-</details>
+## Quick Start
 
----
+Setup largely follows the instructions from the official project. Refer to their documentation for installation and usage details. This fork may contain experimental changes.
 
-<details>
-<summary><strong>Goals of This Fork</strong></summary>
+## License
 
-- **Learning**: To deepen my understanding of LLMs, their architectures, and deployment in local/VM environments.
-- **Experimentation**: To explore optimizations and adaptations for lightweight, local use.
-- **Community Contribution**: To share insights and learnings with others in the open-source community.
+The code in this repository is released under the [MIT License](LICENSE-CODE). Usage of DeepSeek-V3 models is governed by the [Model License](LICENSE-MODEL).
 
-</details>
+## Acknowledgments
 
----
+This project builds on work from the [DeepSeek-AI team](https://github.com/deepseek-ai). Their research made this exploration possible.
 
-<details>
-<summary><strong>Quick Start</strong></summary>
+## Contact
 
-For detailed instructions on setting up and running the model, refer to the official [DeepSeek-V3 README](https://github.com/deepseek-ai/DeepSeek-V3). This fork may include experimental changes, so proceed with caution.
-
-</details>
-
----
-
-<details>
-<summary><strong>License</strong></summary>
-
-This repository is licensed under the [MIT License](LICENSE-CODE). The use of DeepSeek-V3 models is subject to the [Model License](LICENSE-MODEL).
-
-</details>
-
----
-
-<details>
-<summary><strong>Acknowledgments</strong></summary>
-
-This project is based on the incredible work of the [DeepSeek-AI team](https://github.com/deepseek-ai). Special thanks to them for open-sourcing their research and models.
-
-</details>
-
----
-
-<details>
-<summary><strong>Contact</strong></summary>
-
-If you have questions or feedback, feel free to open an issue or reach out. However, for official support, please contact the [DeepSeek-AI team](https://www.deepseek.com/).
-
-</details>
+Questions and feedback are welcome through issues. For official support please visit [DeepSeek-AI](https://www.deepseek.com/).

--- a/inference/convert.py
+++ b/inference/convert.py
@@ -7,6 +7,12 @@ from tqdm import tqdm, trange
 import torch
 from safetensors.torch import safe_open, save_file
 
+"""Convert Hugging Face checkpoints into the format used by this project.
+
+Weights are sharded across model-parallel ranks and saved in the
+``safetensors`` format for efficient loading during inference.
+"""
+
 
 mapping = {
     "embed_tokens": ("embed", 0),

--- a/inference/fp8_cast_bf16.py
+++ b/inference/fp8_cast_bf16.py
@@ -7,6 +7,8 @@ from tqdm import tqdm
 import torch
 from safetensors.torch import load_file, save_file
 
+"""Convert FP8 weights to BF16 for hardware without FP8 support."""
+
 from kernel import weight_dequant
 
 def main(fp8_path, bf16_path):

--- a/inference/generate.py
+++ b/inference/generate.py
@@ -10,6 +10,13 @@ from safetensors.torch import load_model
 
 from model import Transformer, ModelArgs
 
+"""Utilities for generating text with the Transformer model.
+
+This script provides interactive and batch generation modes, handles
+distributed setup and performs token sampling using temperature-based
+techniques.
+"""
+
 
 def sample(logits, temperature: float = 1.0):
     """

--- a/inference/kernel.py
+++ b/inference/kernel.py
@@ -5,6 +5,13 @@ import triton
 import triton.language as tl
 from triton import Config
 
+"""Triton kernels for quantization and FP8 matrix multiplication.
+
+The functions defined here implement activation quantization, weight
+dequantization and a high performance FP8 GEMM routine used by the
+Transformer model during inference.
+"""
+
 
 @triton.jit
 def act_quant_kernel(x_ptr, y_ptr, s_ptr, BLOCK_SIZE: tl.constexpr):

--- a/inference/model.py
+++ b/inference/model.py
@@ -9,6 +9,13 @@ import torch.distributed as dist
 
 from kernel import act_quant, weight_dequant, fp8_gemm
 
+"""Core model components for running the DeepSeek Transformer.
+
+This module contains model argument definitions, parallel embedding and
+linear layers, attention blocks, mixture-of-experts logic and the final
+``Transformer`` class used for inference.
+"""
+
 
 world_size = 1
 rank = 0


### PR DESCRIPTION
## Summary
- clean up README style and remove decorations
- add module descriptions to each Python file

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bd2b1b75c83338826c11560abaeb8