### PR TITLE
Enhance Rust inference module

### DIFF
--- a/inference-re/Cargo.lock
+++ b/inference-re/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23,6 +29,7 @@ dependencies = [
 name = "inference-re"
 version = "0.1.0"
 dependencies = [
+ "ndarray",
  "rand",
 ]
 
@@ -31,6 +38,56 @@ name = "libc"
 version = "0.2.173"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -88,6 +145,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "syn"

--- a/inference-re/Cargo.toml
+++ b/inference-re/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 rand = "0.8"
+ndarray = "0.15"

--- a/inference-re/src/bin/generate.rs
+++ b/inference-re/src/bin/generate.rs
@@ -19,12 +19,12 @@ impl GenerateApp {
     }
 
     /// Generate tokens for a prompt.
-    pub fn generate(&self, prompt: &[i64], max_new: usize) -> Vec<i64> {
+    pub fn generate(&self, prompt: &[usize], max_new: usize) -> Vec<usize> {
 
         let mut rng = rand::thread_rng();
         let mut tokens = prompt.to_vec();
         for _ in 0..max_new {
-            let next: i64 = rng.gen_range(0..self.model.args.vocab_size as i64);
+            let next: usize = rng.gen_range(0..self.model.args.vocab_size);
             tokens.push(next);
         }
         tokens
@@ -36,7 +36,7 @@ fn main() {
     let args = ModelArgs::new();
     let model = Transformer::new(args.clone());
     let app = GenerateApp::new(model);
-    let prompt = vec![0_i64];
+    let prompt = vec![0_usize];
     let out = app.generate(&prompt, 5);
     println!("generated: {:?}", out);
 

--- a/inference-re/src/model.rs
+++ b/inference-re/src/model.rs
@@ -1,66 +1,256 @@
-//! Model components mirroring the Python implementation.
-//!
-//! This module defines the configuration structure and a simplified
-//! Transformer model used for inference tests.
-
+use ndarray::{Array1, Array2, Axis, s};
 use rand::Rng;
 
-/// Model argument configuration.
+/// Configuration for the transformer model.
 #[derive(Clone, Debug)]
 pub struct ModelArgs {
-    /// Maximum sequence length supported by the model.
+    /// Maximum sequence length supported.
     pub max_seq_len: usize,
-    /// Vocabulary size for embeddings.
+    /// Vocabulary size.
     pub vocab_size: usize,
-    /// Embedding dimension size.
+    /// Embedding/hidden dimension.
     pub dim: usize,
+    /// Number of layers.
+    pub n_layers: usize,
+    /// Number of attention heads.
+    pub n_heads: usize,
+    /// Hidden dimension of the feed-forward network.
+    pub hidden_dim: usize,
+}
+
+impl Default for ModelArgs {
+    fn default() -> Self {
+        Self {
+            max_seq_len: 128,
+            vocab_size: 1024,
+            dim: 64,
+            n_layers: 2,
+            n_heads: 4,
+            hidden_dim: 256,
+        }
+    }
 }
 
 impl ModelArgs {
-    /// Create a new set of model arguments with default values.
+    /// Convenience constructor matching the original API.
     pub fn new() -> Self {
-
-        Self {
-            max_seq_len: 4096,
-            vocab_size: 1024,
-            dim: 64,
-        }
+        Self::default()
     }
 }
 
-/// Simple Transformer model for demonstration and testing purposes.
-#[derive(Debug)]
+/// Embedding layer mapping token ids to vectors.
+pub struct Embedding {
+    weight: Array2<f32>, // vocab_size x dim
+}
+
+impl Embedding {
+    pub fn new(vocab_size: usize, dim: usize) -> Self {
+        let mut rng = rand::thread_rng();
+        let weight = Array2::from_shape_fn((vocab_size, dim), |_| rng.gen_range(-0.1..0.1));
+        Self { weight }
+    }
+
+    pub fn forward(&self, tokens: &[usize]) -> Array2<f32> {
+        let mut out = Array2::<f32>::zeros((tokens.len(), self.weight.ncols()));
+        for (i, &tok) in tokens.iter().enumerate() {
+            out.row_mut(i).assign(&self.weight.row(tok));
+        }
+        out
+    }
+}
+
+/// Fully connected layer.
+pub struct Linear {
+    weight: Array2<f32>, // out x in
+    bias: Option<Array1<f32>>,
+}
+
+impl Linear {
+    pub fn new(in_features: usize, out_features: usize, bias: bool) -> Self {
+        let mut rng = rand::thread_rng();
+        let weight = Array2::from_shape_fn((out_features, in_features), |_| rng.gen_range(-0.1..0.1));
+        let bias = if bias {
+            Some(Array1::from_shape_fn(out_features, |_| rng.gen_range(-0.1..0.1)))
+        } else {
+            None
+        };
+        Self { weight, bias }
+    }
+
+    pub fn forward(&self, x: &Array2<f32>) -> Array2<f32> {
+        let mut y = x.dot(&self.weight.t());
+        if let Some(b) = &self.bias {
+            y += &b.view().insert_axis(Axis(0));
+        }
+        y
+    }
+}
+
+/// Root mean square layer normalization.
+pub struct RMSNorm {
+    weight: Array1<f32>,
+    eps: f32,
+}
+
+impl RMSNorm {
+    pub fn new(dim: usize) -> Self {
+        Self {
+            weight: Array1::ones(dim),
+            eps: 1e-6,
+        }
+    }
+
+    pub fn forward(&self, x: &Array2<f32>) -> Array2<f32> {
+        let mean = x.mapv(|v| v * v).mean_axis(Axis(1)).unwrap();
+        let denom = mean.mapv(|m| (m + self.eps).sqrt()).insert_axis(Axis(1));
+        let norm = x / &denom;
+        norm * &self.weight.view().insert_axis(Axis(0))
+    }
+}
+
+/// Multi-head self attention layer.
+pub struct Attention {
+    wq: Linear,
+    wk: Linear,
+    wv: Linear,
+    wo: Linear,
+    n_heads: usize,
+    head_dim: usize,
+}
+
+impl Attention {
+    pub fn new(dim: usize, n_heads: usize) -> Self {
+        let head_dim = dim / n_heads;
+        Self {
+            wq: Linear::new(dim, dim, false),
+            wk: Linear::new(dim, dim, false),
+            wv: Linear::new(dim, dim, false),
+            wo: Linear::new(dim, dim, false),
+            n_heads,
+            head_dim,
+        }
+    }
+
+    pub fn forward(&self, x: &Array2<f32>) -> Array2<f32> {
+        let q = self.wq.forward(x);
+        let k = self.wk.forward(x);
+        let v = self.wv.forward(x);
+        let seq = x.nrows();
+
+        let mut out = Array2::<f32>::zeros((seq, self.n_heads * self.head_dim));
+        for h in 0..self.n_heads {
+            let qh = q.slice(s![.., h * self.head_dim..(h + 1) * self.head_dim]);
+            let kh = k.slice(s![.., h * self.head_dim..(h + 1) * self.head_dim]);
+            let vh = v.slice(s![.., h * self.head_dim..(h + 1) * self.head_dim]);
+
+            // compute attention scores
+            let mut scores = Array2::<f32>::zeros((seq, seq));
+            for i in 0..seq {
+                for j in 0..seq {
+                    let dot = qh.row(i).dot(&kh.row(j));
+                    scores[[i, j]] = dot / (self.head_dim as f32).sqrt();
+                }
+            }
+            // softmax
+            for mut row in scores.axis_iter_mut(Axis(0)) {
+                let max = row.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+                let mut sum = 0.0;
+                for v in row.iter_mut() {
+                    *v = (*v - max).exp();
+                    sum += *v;
+                }
+                for v in row.iter_mut() {
+                    *v /= sum;
+                }
+            }
+            // weighted sum
+            let mut out_h = out.slice_mut(s![.., h * self.head_dim..(h + 1) * self.head_dim]);
+            for i in 0..seq {
+                for j in 0..seq {
+                    let coeff = scores[[i, j]];
+                    for d in 0..self.head_dim {
+                        out_h[[i, d]] += coeff * vh[[j, d]];
+                    }
+                }
+            }
+        }
+        self.wo.forward(&out)
+    }
+}
+
+/// Simple feed-forward network using SILU activation.
+pub struct MLP {
+    w1: Linear,
+    w2: Linear,
+}
+
+impl MLP {
+    pub fn new(dim: usize, hidden_dim: usize) -> Self {
+        Self {
+            w1: Linear::new(dim, hidden_dim, false),
+            w2: Linear::new(hidden_dim, dim, false),
+        }
+    }
+
+    pub fn forward(&self, x: &Array2<f32>) -> Array2<f32> {
+        let hidden = self.w1.forward(x).mapv(|v| v * (1.0 / (1.0 + (-v).exp()))); // silu
+        self.w2.forward(&hidden)
+    }
+}
+
+/// Transformer block consisting of attention and feed-forward layers.
+pub struct Block {
+    attn_norm: RMSNorm,
+    attn: Attention,
+    ffn_norm: RMSNorm,
+    ffn: MLP,
+}
+
+impl Block {
+    pub fn new(args: &ModelArgs) -> Self {
+        Self {
+            attn_norm: RMSNorm::new(args.dim),
+            attn: Attention::new(args.dim, args.n_heads),
+            ffn_norm: RMSNorm::new(args.dim),
+            ffn: MLP::new(args.dim, args.hidden_dim),
+        }
+    }
+
+    pub fn forward(&self, x: &Array2<f32>) -> Array2<f32> {
+        let h = self.attn_norm.forward(x);
+        let h = self.attn.forward(&h);
+        let x = x + &h;
+        let h = self.ffn_norm.forward(&x);
+        let h = self.ffn.forward(&h);
+        x + &h
+    }
+}
+
+/// Full Transformer model used for generation.
 pub struct Transformer {
-    /// Configuration used by the transformer.
     pub args: ModelArgs,
+    embed: Embedding,
+    layers: Vec<Block>,
+    norm: RMSNorm,
+    head: Linear,
 }
 
 impl Transformer {
-    /// Construct a new Transformer instance.
     pub fn new(args: ModelArgs) -> Self {
-
-        Self { args }
+        let embed = Embedding::new(args.vocab_size, args.dim);
+        let layers = (0..args.n_layers).map(|_| Block::new(&args)).collect();
+        let norm = RMSNorm::new(args.dim);
+        let head = Linear::new(args.dim, args.vocab_size, false);
+        Self { args, embed, layers, norm, head }
     }
 
-    /// Forward pass returning dummy logits for the provided tokens.
-    pub fn forward(&self, tokens: &[i64], _start_pos: usize) -> Vec<f32> {
-
-        let mut rng = rand::thread_rng();
-        let mut logits = Vec::new();
-        for _ in 0..tokens.len() {
-            logits.push(rng.gen());
+    pub fn forward(&self, tokens: &[usize]) -> Array2<f32> {
+        let mut h = self.embed.forward(tokens);
+        for layer in &self.layers {
+            h = layer.forward(&h);
         }
-        logits
+        let h = self.norm.forward(&h);
+        self.head.forward(&h)
     }
-}
-
-fn main() {
-
-    let args = ModelArgs::new();
-    let model = Transformer::new(args);
-    let tokens = vec![1_i64, 2, 3];
-    let logits = model.forward(&tokens, 0);
-    println!("logits: {:?}", logits);
-
 }
 

--- a/inference-re/tests/model_tests.rs
+++ b/inference-re/tests/model_tests.rs
@@ -1,0 +1,24 @@
+use inference_re::model::{ModelArgs, Transformer};
+use rand;
+
+#[test]
+fn test_forward_shapes() {
+    let args = ModelArgs::new();
+    let model = Transformer::new(args.clone());
+    let tokens = vec![1_usize, 2, 3];
+    let logits = model.forward(&tokens);
+    assert_eq!(logits.nrows(), tokens.len());
+    assert_eq!(logits.ncols(), args.vocab_size);
+}
+
+#[test]
+fn test_generation_len() {
+    let args = ModelArgs::new();
+    let mut tokens = vec![0_usize];
+    for _ in 0..5 {
+        let next = rand::random::<usize>() % args.vocab_size;
+        tokens.push(next);
+    }
+    assert_eq!(tokens.len(), 6);
+}
+


### PR DESCRIPTION
## Summary
- flesh out `inference-re` transformer implementation
- update generation utility for new API
- depend on `ndarray`
- add integration tests for the Rust model

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6851b1886c9883338135f00d0c586e94