### PR TITLE
Add Release Drafter workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,16 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - feature
+  - title: '🐛 Bug Fixes'
+    labels:
+      - bug
+  - title: '🧰 Maintenance'
+    labels:
+      - chore
+template: |
+  ## Changes
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,21 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  update_release_draft:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ This project builds on work from the [DeepSeek-AI team](https://github.com/deeps
 ## Contact
 
 Questions and feedback are welcome through issues. For official support please visit [DeepSeek-AI](https://www.deepseek.com/).
+
+## Release Notes
+
+Release notes are automatically drafted from merged pull requests using the [Release Drafter GitHub Action](https://github.com/marketplace/actions/release-drafter). Check the "Releases" section on GitHub to see what has changed between versions.


### PR DESCRIPTION
## Summary
- enable auto-drafted release notes via `release-drafter` action
- document automated release notes in the README

## Testing
- `cargo test --manifest-path inference-re/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_6852e92c1c28833397db9dc1e4b1f977