### PR TITLE
Add Rust CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,18 @@
+name: Rust CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Run tests
+        run: cargo test --manifest-path inference-re/Cargo.toml


### PR DESCRIPTION
## Summary
- set up Rust CI workflow for `inference-re`

## Testing
- `cargo test --manifest-path inference-re/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_6853487152f48333acfa3d1a49df0dd2