### PR TITLE
Add Rust mobile quantizer

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,3 +16,5 @@ jobs:
           override: true
       - name: Run tests
         run: cargo test --manifest-path inference-re/Cargo.toml
+      - name: Build mobile crate
+        run: cargo build --release --manifest-path mobile/Cargo.toml

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ This fork demonstrates how large language models can be adapted for local-first 
 ### Mobile Deployment Edge Cases
 
 Running the full DeepSeek-V3 model on a phone is unrealistic: the 671B parameter version requires hundreds of gigabytes of memory. Phones may, however, run a distilled or heavily quantized model. Expect reduced accuracy, slower responses, and significant battery usage. These experiments are best suited to high-end devices and remain experimental.
+
+### Mobile Tools
+
+This repository now ships a small Rust program under `mobile/` that demonstrates quantizing the example model for use on phones. See [`mobile/README.md`](mobile/README.md) for build instructions.
 ## License
 
 The code in this repository is released under the [MIT License](LICENSE-CODE). Usage of DeepSeek-V3 models is governed by the [Model License](LICENSE-MODEL).

--- a/inference-re/src/model.rs
+++ b/inference-re/src/model.rs
@@ -57,6 +57,11 @@ impl Embedding {
         }
         out
     }
+
+    /// Access underlying weight matrix.
+    pub fn weight(&self) -> &Array2<f32> {
+        &self.weight
+    }
 }
 
 /// Fully connected layer.
@@ -83,6 +88,16 @@ impl Linear {
             y += &b.view().insert_axis(Axis(0));
         }
         y
+    }
+
+    /// Access weight matrix.
+    pub fn weight(&self) -> &Array2<f32> {
+        &self.weight
+    }
+
+    /// Access bias vector, if present.
+    pub fn bias(&self) -> Option<&Array1<f32>> {
+        self.bias.as_ref()
     }
 }
 
@@ -251,6 +266,16 @@ impl Transformer {
         }
         let h = self.norm.forward(&h);
         self.head.forward(&h)
+    }
+
+    /// Access embedding layer.
+    pub fn embed(&self) -> &Embedding {
+        &self.embed
+    }
+
+    /// Access output head.
+    pub fn head(&self) -> &Linear {
+        &self.head
     }
 }
 

--- a/mobile/Cargo.toml
+++ b/mobile/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "mobile"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+ndarray = "0.15"
+inference-re = { path = "../inference-re" }
+bytemuck = { version = "1.14", features = ["derive"] }

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,21 @@
+# Mobile Deployment Guide
+
+This folder now contains a lightweight Rust tool for quantizing the demo transformer model from this repository. The resulting file can be loaded by custom mobile runtimes.
+
+## Build
+
+```bash
+cargo build --release --manifest-path mobile/Cargo.toml
+```
+
+## Usage
+
+```bash
+./target/release/mobile --out quantized.bin
+```
+
+The tool creates `quantized.bin` containing 8-bit versions of the embedding and output head. It serves as a minimal example of preparing weights for on-device inference.
+
+## Limitations
+
+This example quantizes only a toy model and does not load external checkpoints. Adapting it for real-world models like the DeepSeek distilled series will require significant additional work.

--- a/mobile/src/main.rs
+++ b/mobile/src/main.rs
@@ -1,0 +1,104 @@
+use clap::Parser;
+use inference_re::model::{ModelArgs, Transformer, Linear, Embedding};
+use ndarray::{Array1, Array2};
+use std::{fs::File, io::Write, path::PathBuf};
+use bytemuck::cast_slice;
+
+/// Simple quantization of a tensor to 8-bit integers with a scale factor.
+fn quantize_tensor(t: &Array2<f32>) -> (Vec<i8>, f32) {
+    let max = t.iter().fold(0.0_f32, |m, &v| m.max(v.abs()));
+    let scale = if max == 0.0 { 1.0 } else { 127.0 / max };
+    let data = t.iter().map(|&v| (v * scale).round() as i8).collect();
+    (data, 1.0 / scale)
+}
+
+/// Quantized linear layer.
+struct QLinear {
+    weight: Vec<i8>,
+    bias: Option<Array1<f32>>,
+    scale: f32,
+    in_features: usize,
+    out_features: usize,
+}
+
+impl QLinear {
+    fn from_linear(l: &Linear) -> Self {
+        let (weight, scale) = quantize_tensor(l.weight());
+        Self {
+            weight,
+            bias: l.bias().cloned(),
+            scale,
+            in_features: l.weight().ncols(),
+            out_features: l.weight().nrows(),
+        }
+    }
+}
+
+/// Quantized embedding layer.
+struct QEmbedding {
+    weight: Vec<i8>,
+    scale: f32,
+    vocab: usize,
+    dim: usize,
+}
+
+impl QEmbedding {
+    fn from_embedding(e: &Embedding) -> Self {
+        let (weight, scale) = quantize_tensor(e.weight());
+        Self { weight, scale, vocab: e.weight().nrows(), dim: e.weight().ncols() }
+    }
+}
+
+/// Quantized transformer holding only embedding and head for demo purposes.
+struct QTransformer {
+    embed: QEmbedding,
+    head: QLinear,
+}
+
+impl QTransformer {
+    fn from_model(m: &Transformer) -> Self {
+        Self {
+            embed: QEmbedding::from_embedding(m.embed()),
+            head: QLinear::from_linear(m.head()),
+        }
+    }
+
+    fn save(&self, path: &PathBuf) -> std::io::Result<()> {
+        let mut f = File::create(path)?;
+        // write embedding
+        f.write_all(&(self.embed.vocab as u32).to_le_bytes())?;
+        f.write_all(&(self.embed.dim as u32).to_le_bytes())?;
+        f.write_all(&self.embed.scale.to_le_bytes())?;
+        f.write_all(cast_slice(&self.embed.weight))?;
+        // write head
+        f.write_all(&(self.head.out_features as u32).to_le_bytes())?;
+        f.write_all(&(self.head.in_features as u32).to_le_bytes())?;
+        f.write_all(&self.head.scale.to_le_bytes())?;
+        f.write_all(cast_slice(&self.head.weight))?;
+        if let Some(b) = &self.head.bias {
+            f.write_all(&1u8.to_le_bytes())?;
+            for v in b.iter() { f.write_all(&v.to_le_bytes())?; }
+        } else {
+            f.write_all(&0u8.to_le_bytes())?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Parser)]
+struct Args {
+    /// Output file for the quantized model
+    #[arg(long, default_value = "model.q8")]
+    out: PathBuf,
+}
+
+fn main() -> std::io::Result<()> {
+    let args = Args::parse();
+
+    // create tiny transformer and quantize
+    let model = Transformer::new(ModelArgs::new());
+    let q = QTransformer::from_model(&model);
+    q.save(&args.out)?;
+    println!("Saved quantized model to {:?}", args.out);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- replace Python script with a Rust-based quantization example
- expose model weights in `inference-re` crate for tooling
- document the new mobile tool and how to build it
- compile the mobile crate in CI

## Testing
- `cargo test --manifest-path inference-re/Cargo.toml`
- `cargo build --release --manifest-path mobile/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68538433fb688333935b123a108a83f7