### PR TITLE
Add simple tokenizer

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -37,6 +37,20 @@ let logits = model.forward(&tokens);
 let generated = model.generate(&tokens, 4);
 ```
 
+### Tokenization
+
+The `Tokenizer` type handles simple whitespace tokenization. Create it from a
+list of tokens and use `encode` and `decode` to convert between text and token
+ids.
+
+```rust
+use mobile::Tokenizer;
+
+let tokenizer = Tokenizer::new(vec!["<unk>".into(), "hello".into(), "world".into()]);
+let ids = tokenizer.encode("hello world");
+let text = tokenizer.decode(&ids);
+```
+
 ## Limitations
 
 This example quantizes only a toy model and does not load external checkpoints. Adapting it for real-world models like the DeepSeek distilled series will require significant additional work.

--- a/mobile/tests/tokenizer_tests.rs
+++ b/mobile/tests/tokenizer_tests.rs
@@ -1,0 +1,21 @@
+use mobile::Tokenizer;
+
+#[test]
+fn encode_decode_roundtrip() {
+    let tokens = vec!["<unk>".to_string(), "hello".to_string(), "world".to_string()];
+    let tokenizer = Tokenizer::new(tokens);
+    let ids = tokenizer.encode("hello world");
+    assert_eq!(ids, vec![1, 2]);
+    let text = tokenizer.decode(&ids);
+    assert_eq!(text, "hello world");
+}
+
+#[test]
+fn unknown_token() {
+    let tokens = vec!["<unk>".to_string(), "foo".to_string()];
+    let tokenizer = Tokenizer::new(tokens);
+    let ids = tokenizer.encode("bar");
+    assert_eq!(ids, vec![0]);
+    let text = tokenizer.decode(&ids);
+    assert_eq!(text, "<unk>");
+}


### PR DESCRIPTION
## Summary
- provide whitespace `Tokenizer` for simple text -> token conversion
- document how to use the tokenizer in README
- test tokenizer encoding and decoding

## Testing
- `cargo test --manifest-path mobile/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68538ec83af48333acb11f59cee249ce