### PR TITLE
Add C FFI for mobile runtime

### DIFF
--- a/mobile/Cargo.toml
+++ b/mobile/Cargo.toml
@@ -12,6 +12,7 @@ memmap2 = "0.5"
 
 [lib]
 path = "src/lib.rs"
+crate-type = ["cdylib", "rlib"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -51,6 +51,34 @@ let ids = tokenizer.encode("hello world");
 let text = tokenizer.decode(&ids);
 ```
 
+### C FFI
+
+The library exposes a small C-compatible API for integration with native mobile
+applications. Build the crate as a `cdylib` to obtain a shared library.
+
+```bash
+cargo build --release --manifest-path mobile/Cargo.toml
+```
+
+Key functions include:
+
+```c
+QTransformer* mobile_model_load(const char* path);
+void mobile_model_free(QTransformer* model);
+TokenArray mobile_generate(QTransformer* model, const size_t* ids,
+                           size_t len, size_t max_tokens);
+void token_array_free(TokenArray arr);
+
+Tokenizer* tokenizer_new(const char* const* tokens, size_t len);
+void tokenizer_free(Tokenizer* t);
+TokenArray tokenizer_encode(Tokenizer* t, const char* text);
+char* tokenizer_decode(Tokenizer* t, const size_t* ids, size_t len);
+void string_free(char* s);
+```
+
+The `TokenArray` struct holds a pointer and length for arrays returned by the
+library. Call the corresponding `*_free` functions to release allocated memory.
+
 ## Limitations
 
 This example quantizes only a toy model and does not load external checkpoints. Adapting it for real-world models like the DeepSeek distilled series will require significant additional work.

--- a/mobile/tests/ffi_tests.rs
+++ b/mobile/tests/ffi_tests.rs
@@ -1,0 +1,46 @@
+use inference_re::model::{ModelArgs, Transformer};
+use mobile::*;
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+use tempfile::NamedTempFile;
+
+#[test]
+fn ffi_model_and_tokenizer() {
+    let model = Transformer::new(ModelArgs::new());
+    let q = QTransformer::from_model(&model);
+    let tmp = NamedTempFile::new().unwrap();
+    q.save(&tmp.path().to_path_buf()).unwrap();
+
+    unsafe {
+        let path = CString::new(tmp.path().to_str().unwrap()).unwrap();
+        let m = mobile_model_load(path.as_ptr());
+        assert!(!m.is_null());
+
+        let vocab = [
+            CString::new("<unk>").unwrap(),
+            CString::new("hello").unwrap(),
+            CString::new("world").unwrap(),
+        ];
+        let ptrs: Vec<*const c_char> = vocab.iter().map(|s| s.as_ptr()).collect();
+        let tok = tokenizer_new(ptrs.as_ptr(), ptrs.len());
+        assert!(!tok.is_null());
+
+        let text = CString::new("hello").unwrap();
+        let ids = tokenizer_encode(tok, text.as_ptr());
+        assert_eq!(ids.len, 1);
+
+        let generated = mobile_generate(m, ids.ptr, ids.len, 2);
+        assert!(generated.len >= ids.len);
+
+        let decoded_ptr = tokenizer_decode(tok, generated.ptr, generated.len);
+        assert!(!decoded_ptr.is_null());
+        let _decoded = CStr::from_ptr(decoded_ptr).to_str().unwrap();
+
+        string_free(decoded_ptr);
+        token_array_free(ids);
+        token_array_free(generated);
+        tokenizer_free(tok);
+        mobile_model_free(m);
+    }
+}
+


### PR DESCRIPTION
## Summary
- expose QTransformer and Tokenizer through a minimal C API
- generate shared library (`cdylib`) and document the interface
- test FFI functions for model loading, generation, and tokenization

## Testing
- `cargo test --manifest-path mobile/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_685395d075988333a7fd05957ef70cf4