### PR TITLE
Add C ABI inference interface

### DIFF
--- a/mobile/src/ffi.rs
+++ b/mobile/src/ffi.rs
@@ -1,0 +1,50 @@
+use super::QTransformer;
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+use std::path::PathBuf;
+
+#[repr(C)]
+pub struct InferenceEngine {
+    model: QTransformer,
+}
+
+#[no_mangle]
+pub extern "C" fn inference_new(model_path: *const c_char) -> *mut InferenceEngine {
+    if model_path.is_null() {
+        return std::ptr::null_mut();
+    }
+    let c_str = unsafe { CStr::from_ptr(model_path) };
+    let path = PathBuf::from(c_str.to_string_lossy().into_owned());
+    match QTransformer::load_mmap(&path).or_else(|_| QTransformer::load(&path)) {
+        Ok(model) => Box::into_raw(Box::new(InferenceEngine { model })),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn inference_run(
+    engine: *mut InferenceEngine,
+    input_ids: *const usize,
+    len: usize,
+    out_ptr: *mut usize,
+    out_len: *mut usize,
+) -> c_int {
+    if engine.is_null() || input_ids.is_null() || out_ptr.is_null() || out_len.is_null() {
+        return -1;
+    }
+    let engine = unsafe { &mut *engine };
+    let input = unsafe { std::slice::from_raw_parts(input_ids, len) };
+    let output = engine.model.generate(input, 1);
+    unsafe {
+        std::ptr::copy_nonoverlapping(output.as_ptr(), out_ptr, output.len());
+        *out_len = output.len();
+    }
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn inference_free(engine: *mut InferenceEngine) {
+    if !engine.is_null() {
+        unsafe { drop(Box::from_raw(engine)); }
+    }
+}

--- a/mobile/src/lib.rs
+++ b/mobile/src/lib.rs
@@ -4,6 +4,9 @@ use std::{collections::HashMap, fs::File, io::Write, path::PathBuf};
 use bytemuck::cast_slice;
 use memmap2::MmapOptions;
 
+pub mod ffi;
+pub use ffi::*;
+
 /// Simple quantization of a tensor to 8-bit integers with a scale factor.
 fn quantize_tensor(t: &Array2<f32>) -> (Vec<i8>, f32) {
     let max = t.iter().fold(0.0_f32, |m, &v| m.max(v.abs()));


### PR DESCRIPTION
## Summary
- create `ffi` module exposing `InferenceEngine` with `inference_new`, `inference_run`, and `inference_free`
- re-export all FFI functions from crate root

## Testing
- `cargo build --manifest-path mobile/Cargo.toml`
- `cargo test --manifest-path mobile/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68547fbf6b04833387b507e591821a18