### PR TITLE
Fix world slug handling

### DIFF
--- a/src/pages/WorldExperiencePage.tsx
+++ b/src/pages/WorldExperiencePage.tsx
@@ -1,0 +1,35 @@
+import { useParams, Navigate } from "react-router-dom";
+import { ExperienceProvider } from "@/context/ExperienceContext";
+import ExperienceContent from "@/components/experience/ExperienceContent";
+import { useWorldBySlug } from "@/hooks/useWorlds";
+import LoadingOverlay from "@/components/experience/LoadingOverlay";
+
+const WorldExperiencePage = () => {
+
+  const { worldSlug } = useParams<{ worldSlug: string }>();
+
+  const slug = worldSlug
+    ? decodeURIComponent(worldSlug).trim().toLowerCase()
+    : '';
+
+  const { data: world, isLoading, isError } = useWorldBySlug(slug);
+
+  if (isLoading) {
+    return <LoadingOverlay message="Loading world..." theme="night" />;
+  }
+
+  if (isError || !world) {
+    return <Navigate to="/" replace />;
+  }
+
+  return (
+
+    <ExperienceProvider>
+      <ExperienceContent initialWorldSlug={slug} />
+    </ExperienceProvider>
+  
+  );
+
+};
+
+export default WorldExperiencePage;


### PR DESCRIPTION
## Summary
- decode slug from URL before loading world data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68570bf7e5e88333aee87e0f48431a5d