### PR TITLE
Feature: expose token_id in tokenizer

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -51,6 +51,7 @@ let ids = tokenizer.encode("hello world");
 let text = tokenizer.decode(&ids);
 let vocab_size = tokenizer.vocab_size();
 let has_token = tokenizer.contains("hello");
+let maybe_id = tokenizer.token_id("world");
 ```
 
 ### C FFI
@@ -77,6 +78,7 @@ TokenArray tokenizer_encode(Tokenizer* t, const char* text);
 char* tokenizer_decode(Tokenizer* t, const size_t* ids, size_t len);
 size_t tokenizer_vocab_size(Tokenizer* t);
 bool tokenizer_contains(Tokenizer* t, const char* token);
+isize tokenizer_token_id(Tokenizer* t, const char* token);
 void string_free(char* s);
 ```
 

--- a/mobile/src/lib.rs
+++ b/mobile/src/lib.rs
@@ -355,6 +355,19 @@ pub extern "C" fn tokenizer_contains(
     tok.contains(&text)
 }
 
+#[no_mangle]
+pub extern "C" fn tokenizer_token_id(
+    tokenizer: *mut Tokenizer,
+    token: *const c_char,
+) -> isize {
+    if tokenizer.is_null() || token.is_null() {
+        return -1;
+    }
+    let tok = unsafe { &mut *tokenizer };
+    let text = unsafe { CStr::from_ptr(token).to_string_lossy() };
+    tok.token_id(&text).map(|id| id as isize).unwrap_or(-1)
+}
+
 /// Simple whitespace tokenizer backed by a fixed vocabulary.
 pub struct Tokenizer {
     vocab: HashMap<String, usize>,
@@ -404,5 +417,11 @@ impl Tokenizer {
     #[inline]
     pub fn contains(&self, token: &str) -> bool {
         self.vocab.contains_key(token)
+    }
+
+    /// Get the id of a token if it exists in the vocabulary.
+    #[inline]
+    pub fn token_id(&self, token: &str) -> Option<usize> {
+        self.vocab.get(token).cloned()
     }
 }

--- a/mobile/tests/ffi_tests.rs
+++ b/mobile/tests/ffi_tests.rs
@@ -80,3 +80,17 @@ fn ffi_tokenizer_contains() {
     }
 }
 
+#[test]
+fn ffi_tokenizer_token_id() {
+    unsafe {
+        let vocab = [CString::new("<unk>").unwrap(), CString::new("x").unwrap()];
+        let ptrs: Vec<*const c_char> = vocab.iter().map(|s| s.as_ptr()).collect();
+        let tok = tokenizer_new(ptrs.as_ptr(), ptrs.len());
+        assert!(!tok.is_null());
+        let token = CString::new("x").unwrap();
+        assert_eq!(tokenizer_token_id(tok, token.as_ptr()), 1);
+        let missing = CString::new("y").unwrap();
+        assert_eq!(tokenizer_token_id(tok, missing.as_ptr()), -1);
+        tokenizer_free(tok);
+    }
+}

--- a/mobile/tests/tokenizer_tests.rs
+++ b/mobile/tests/tokenizer_tests.rs
@@ -2,7 +2,11 @@ use mobile::Tokenizer;
 
 #[test]
 fn encode_decode_roundtrip() {
-    let tokens = vec!["<unk>".to_string(), "hello".to_string(), "world".to_string()];
+    let tokens = vec![
+        "<unk>".to_string(),
+        "hello".to_string(),
+        "world".to_string(),
+    ];
     let tokenizer = Tokenizer::new(tokens);
     let ids = tokenizer.encode("hello world");
     assert_eq!(ids, vec![1, 2]);
@@ -33,4 +37,12 @@ fn contains_checks_presence() {
     let tokenizer = Tokenizer::new(tokens);
     assert!(tokenizer.contains("foo"));
     assert!(!tokenizer.contains("bar"));
+}
+
+#[test]
+fn token_id_returns_some_when_present() {
+    let tokens = vec!["<unk>".to_string(), "a".to_string(), "b".to_string()];
+    let tokenizer = Tokenizer::new(tokens);
+    assert_eq!(tokenizer.token_id("b"), Some(2));
+    assert_eq!(tokenizer.token_id("missing"), None);
 }


### PR DESCRIPTION
## Summary
- add `token_id` to the Rust tokenizer and expose via FFI
- document the new API in the mobile README
- test direct and FFI usage of `token_id`

## Codex CI
- `cargo test --manifest-path mobile/Cargo.toml`
- `cargo test --manifest-path inference-re/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68602cbd64308333b87f57d879a5e088